### PR TITLE
GH-5 mappers for Ad, Comment and User

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
   <properties>
     <java.version>17</java.version>
+    <lombok.version>1.18.28</lombok.version>
   </properties>
 
   <dependencies>
@@ -48,6 +49,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+      <version>1.5.5.Final</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-ui</artifactId>
       <version>1.7.0</version>
@@ -62,6 +69,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -94,6 +102,26 @@
               <artifactId>lombok</artifactId>
             </exclude>
           </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <release>17</release>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>1.5.5.Final</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/ru/skypro/flea/dto/CommentsDto.java
+++ b/src/main/java/ru/skypro/flea/dto/CommentsDto.java
@@ -11,6 +11,6 @@ public class CommentsDto {
     @Schema(description = "Total amount of comments")
     private Integer count;
 
-    private List<CommentDto> result;
+    private List<CommentDto> results;
 
 }

--- a/src/main/java/ru/skypro/flea/mapper/AdMapper.java
+++ b/src/main/java/ru/skypro/flea/mapper/AdMapper.java
@@ -1,0 +1,43 @@
+package ru.skypro.flea.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import ru.skypro.flea.dto.AdDto;
+import ru.skypro.flea.dto.AdsDto;
+import ru.skypro.flea.dto.CreateOrUpdateAdDto;
+import ru.skypro.flea.dto.ExtendedAdDto;
+import ru.skypro.flea.model.Ad;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mapper
+public interface AdMapper {
+
+    @Mapping(target = "author", source = "user.id")
+    @Mapping(target = "pk", source = "id")
+    AdDto toAdDto(Ad entity);
+
+    List<AdDto> toAdDtoList(Collection<Ad> ads);
+
+    default AdsDto toAdsDto(Collection<Ad> ads) {
+        AdsDto dto = new AdsDto();
+        dto.setResults(toAdDtoList(ads));
+        dto.setCount(ads.size());
+
+        return dto;
+    }
+
+    @Mapping(target = "pk", source = "id")
+    @Mapping(target = "authorFirstName", source = "user.firstName")
+    @Mapping(target = "authorLastName", source = "user.lastName")
+    @Mapping(target = "email", source = "user.email")
+    @Mapping(target = "phone", source = "user.phone")
+    ExtendedAdDto toExtendedAdDto(Ad entity);
+
+    Ad createAdFromDto(String image, CreateOrUpdateAdDto dto);
+
+    void updateAdFromDto(@MappingTarget Ad ad, CreateOrUpdateAdDto dto);
+
+}

--- a/src/main/java/ru/skypro/flea/mapper/CommentMapper.java
+++ b/src/main/java/ru/skypro/flea/mapper/CommentMapper.java
@@ -1,0 +1,44 @@
+package ru.skypro.flea.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import ru.skypro.flea.dto.CommentDto;
+import ru.skypro.flea.dto.CommentsDto;
+import ru.skypro.flea.dto.CreateOrUpdateCommentDto;
+import ru.skypro.flea.model.Comment;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mapper
+public interface CommentMapper {
+
+    @Mapping(target = "author", source = "user.id")
+    @Mapping(target = "authorImage", source = "user.image")
+    @Mapping(target = "authorFirstName", source = "user.firstName")
+    @Mapping(target = "createdAt",
+            expression = "java(entity.getPublicDate()" +
+                    ".toInstant(java.time.OffsetDateTime.now().getOffset())" +
+                    ".toEpochMilli())")
+    @Mapping(target = "pk", source = "id")
+    @Mapping(target = "text", source = "title")
+    CommentDto toCommentDto(Comment entity);
+
+    List<CommentDto> toCommentDtoList(Collection<Comment> comments);
+
+    default CommentsDto toCommentsDto(Collection<Comment> comments) {
+        CommentsDto dto = new CommentsDto();
+        dto.setResults(toCommentDtoList(comments));
+        dto.setCount(comments.size());
+
+        return dto;
+    }
+
+    @Mapping(target = "title", source = "text")
+    Comment createCommentFromDto(CreateOrUpdateCommentDto dto);
+
+    @Mapping(target = "title", source = "text")
+    void updateCommentFromDto(@MappingTarget Comment comment, CreateOrUpdateCommentDto dto);
+
+}

--- a/src/main/java/ru/skypro/flea/mapper/UserMapper.java
+++ b/src/main/java/ru/skypro/flea/mapper/UserMapper.java
@@ -1,0 +1,21 @@
+package ru.skypro.flea.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import ru.skypro.flea.dto.RegisterDto;
+import ru.skypro.flea.dto.UpdateUserDto;
+import ru.skypro.flea.dto.UserDto;
+import ru.skypro.flea.model.User;
+
+@Mapper
+public interface UserMapper {
+
+    UserDto toUserDto(User entity);
+
+    @Mapping(target = "email", source = "username")
+    User createUserFromDto(RegisterDto dto);
+
+    void updateUserFromDto(@MappingTarget User user, UpdateUserDto dto);
+
+}

--- a/src/test/java/ru/skypro/flea/mapper/AdMapperTest.java
+++ b/src/test/java/ru/skypro/flea/mapper/AdMapperTest.java
@@ -1,0 +1,141 @@
+package ru.skypro.flea.mapper;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import ru.skypro.flea.dto.AdDto;
+import ru.skypro.flea.dto.AdsDto;
+import ru.skypro.flea.dto.CreateOrUpdateAdDto;
+import ru.skypro.flea.dto.ExtendedAdDto;
+import ru.skypro.flea.model.Ad;
+import ru.skypro.flea.model.User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdMapperTest {
+
+    private static Ad defaultAd;
+
+    private final AdMapper mapper = Mappers.getMapper(AdMapper.class);
+
+    @BeforeAll
+    public static void fillDefaultAd() {
+        User defaultAuthor = new User();
+        defaultAuthor.setId(123);
+        defaultAuthor.setFirstName("John");
+        defaultAuthor.setLastName("Brown");
+        defaultAuthor.setEmail("john.brown2007@example.com");
+        defaultAuthor.setPhone("+0(000)000-00-00");
+
+        defaultAd = new Ad();
+        defaultAd.setUser(defaultAuthor);
+        defaultAd.setImage("https://imagehostingservice.org/4jhf1n31.png");
+        defaultAd.setId(456);
+        defaultAd.setPrice(100500);
+        defaultAd.setTitle("Dubstep machine");
+        defaultAd.setDescription("Simple to use, very affordable");
+    }
+
+    @Test
+    public void adToAdDtoMappingTest() {
+        AdDto dto = mapper.toAdDto(defaultAd);
+
+        assertEntityEqualsToDto(defaultAd, dto);
+    }
+
+    @Test
+    public void emptyAdCollectionToAdDtoListMappingTest() {
+        Collection<Ad> emptyEntityList = Collections.emptyList();
+
+        List<AdDto> dtoList = mapper.toAdDtoList(emptyEntityList);
+
+        assertTrue(dtoList.isEmpty());
+    }
+
+    @Test
+    public void adCollectionToAdDtoListMappingTest() {
+        Collection<Ad> entityList = Collections.singletonList(defaultAd);
+
+        List<AdDto> dtoList = mapper.toAdDtoList(entityList);
+
+        assertEquals(dtoList.size(), 1);
+        assertEntityEqualsToDto(defaultAd, dtoList.get(0));
+    }
+
+    @Test
+    public void adCollectionToAdsDtoMappingTest() {
+        Collection<Ad> entityList = Collections.singletonList(defaultAd);
+
+        AdsDto dto = mapper.toAdsDto(entityList);
+
+        assertEquals(dto.getCount(), 1);
+        assertEquals(dto.getResults().size(), 1);
+        assertEntityEqualsToDto(defaultAd, dto.getResults().get(0));
+    }
+
+    @Test
+    public void adToExtendedAdDtoMappingTest() {
+        ExtendedAdDto dto = mapper.toExtendedAdDto(defaultAd);
+
+        assertEntityEqualsToExtendedDto(defaultAd, dto);
+    }
+
+    @Test
+    public void creatingAdFromCreateOrUpdateAdDtoTest() {
+        CreateOrUpdateAdDto dto = new CreateOrUpdateAdDto();
+        dto.setTitle("Title");
+        dto.setPrice(1);
+        dto.setDescription("Description");
+        String imageLink = "https://imagehostingservice.org/fjh32bn.png";
+
+        Ad entity = mapper.createAdFromDto(imageLink, dto);
+        assertEquals(entity.getTitle(), dto.getTitle());
+        assertEquals(entity.getPrice(), dto.getPrice());
+        assertEquals(entity.getDescription(), dto.getDescription());
+        assertEquals(entity.getImage(), imageLink);
+    }
+
+    @Test
+    public void updatingAdFromCreateOrUpdateAdDtoTest() {
+        Ad entity = new Ad();
+        entity.setTitle("Old title");
+        entity.setPrice(1);
+        entity.setDescription("Old description");
+
+        CreateOrUpdateAdDto dto = new CreateOrUpdateAdDto();
+        dto.setTitle("New title");
+        dto.setPrice(2);
+        dto.setDescription("New description");
+
+        mapper.updateAdFromDto(entity, dto);
+
+        assertEquals(entity.getTitle(), dto.getTitle());
+        assertEquals(entity.getPrice(), dto.getPrice());
+        assertEquals(entity.getDescription(), dto.getDescription());
+    }
+
+    private void assertEntityEqualsToDto(Ad entity, AdDto dto) {
+        assertEquals(dto.getAuthor(), entity.getUser().getId());
+        assertEquals(dto.getImage(), entity.getImage());
+        assertEquals(dto.getPk(), entity.getId());
+        assertEquals(dto.getPrice(), entity.getPrice());
+        assertEquals(dto.getTitle(), entity.getTitle());
+    }
+
+    private void assertEntityEqualsToExtendedDto(Ad entity, ExtendedAdDto dto) {
+        assertEquals(dto.getPk(), entity.getId());
+        assertEquals(dto.getAuthorFirstName(), entity.getUser().getFirstName());
+        assertEquals(dto.getAuthorLastName(), entity.getUser().getLastName());
+        assertEquals(dto.getDescription(), entity.getDescription());
+        assertEquals(dto.getEmail(), entity.getUser().getEmail());
+        assertEquals(dto.getImage(), entity.getImage());
+        assertEquals(dto.getPhone(), entity.getUser().getPhone());
+        assertEquals(dto.getPrice(), entity.getPrice());
+        assertEquals(dto.getTitle(), entity.getTitle());
+    }
+
+}

--- a/src/test/java/ru/skypro/flea/mapper/CommentMapperTest.java
+++ b/src/test/java/ru/skypro/flea/mapper/CommentMapperTest.java
@@ -1,0 +1,114 @@
+package ru.skypro.flea.mapper;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import ru.skypro.flea.dto.CommentDto;
+import ru.skypro.flea.dto.CommentsDto;
+import ru.skypro.flea.dto.CreateOrUpdateCommentDto;
+import ru.skypro.flea.model.Comment;
+import ru.skypro.flea.model.User;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CommentMapperTest {
+
+    private static final long defaultTimeStamp = 1000L;
+
+    private static Comment defaultComment;
+
+    private final CommentMapper mapper = Mappers.getMapper(CommentMapper.class);
+
+    @BeforeAll
+    public static void fillDefaultComment() {
+        User defaultAuthor = new User();
+        defaultAuthor.setId(123);
+        defaultAuthor.setImage("https://imagehostingservice.org/vh4jbf3.png");
+        defaultAuthor.setFirstName("John");
+
+        defaultComment = new Comment();
+        defaultComment.setId(456);
+        defaultComment.setTitle("Broken after 10 minutes of use");
+        defaultComment.setPublicDate(LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(defaultTimeStamp),
+                TimeZone.getDefault().toZoneId()));
+        defaultComment.setUser(defaultAuthor);
+    }
+
+    @Test
+    public void commentToCommentDtoMappingTest() {
+        CommentDto dto = mapper.toCommentDto(defaultComment);
+
+        assertEntityEqualsToDto(defaultComment, dto);
+    }
+
+    @Test
+    public void emptyCommentCollectionToCommentDtoListMappingTest() {
+        Collection<Comment> emptyEntityList = Collections.emptyList();
+
+        List<CommentDto> dtoList = mapper.toCommentDtoList(emptyEntityList);
+
+        assertTrue(dtoList.isEmpty());
+    }
+
+    @Test
+    public void commentCollectionToCommentDtoListMappingTest() {
+        Collection<Comment> entityList = Collections.singletonList(defaultComment);
+
+        List<CommentDto> dtoList = mapper.toCommentDtoList(entityList);
+
+        assertEquals(dtoList.size(), 1);
+        assertEntityEqualsToDto(defaultComment, dtoList.get(0));
+    }
+
+    @Test
+    public void commentCollectionToCommentsDtoMappingTest() {
+        Collection<Comment> entityList = Collections.singletonList(defaultComment);
+
+        CommentsDto dto = mapper.toCommentsDto(entityList);
+
+        assertEquals(dto.getCount(), 1);
+        assertEquals(dto.getResults().size(), 1);
+        assertEntityEqualsToDto(defaultComment, dto.getResults().get(0));
+    }
+
+    @Test
+    public void creatingCommentFromCreateOrUpdateCommentDtoTest() {
+        CreateOrUpdateCommentDto dto = new CreateOrUpdateCommentDto();
+        dto.setText("Comment");
+
+        Comment entity = mapper.createCommentFromDto(dto);
+
+        assertEquals(entity.getTitle(), dto.getText());
+    }
+
+    @Test
+    public void updatingCommentFromCreateOrUpdateCommentDtoTest() {
+        Comment entity = new Comment();
+        entity.setTitle("Old comment");
+
+        CreateOrUpdateCommentDto dto = new CreateOrUpdateCommentDto();
+        dto.setText("New comment");
+
+        mapper.updateCommentFromDto(entity, dto);
+
+        assertEquals(entity.getTitle(), dto.getText());
+    }
+
+    private void assertEntityEqualsToDto(Comment entity, CommentDto dto) {
+        assertEquals(dto.getAuthor(), entity.getUser().getId());
+        assertEquals(dto.getAuthorImage(), entity.getUser().getImage());
+        assertEquals(dto.getAuthorFirstName(), entity.getUser().getFirstName());
+        assertEquals(dto.getCreatedAt(), defaultTimeStamp);
+        assertEquals(dto.getPk(), entity.getId());
+    }
+
+}

--- a/src/test/java/ru/skypro/flea/mapper/UserMapperTest.java
+++ b/src/test/java/ru/skypro/flea/mapper/UserMapperTest.java
@@ -1,0 +1,88 @@
+package ru.skypro.flea.mapper;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import ru.skypro.flea.dto.RegisterDto;
+import ru.skypro.flea.dto.UpdateUserDto;
+import ru.skypro.flea.dto.UserDto;
+import ru.skypro.flea.model.User;
+import ru.skypro.flea.model.enums.Role;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserMapperTest {
+
+    private static User defaultUser;
+
+    private final UserMapper mapper = Mappers.getMapper(UserMapper.class);
+
+    @BeforeAll
+    public static void fillDefaultUser() {
+        defaultUser = new User();
+        defaultUser.setId(123);
+        defaultUser.setFirstName("John");
+        defaultUser.setLastName("Brown");
+        defaultUser.setEmail("john.brown2007@example.com");
+        defaultUser.setPhone("+7(000)000-00-00");
+        defaultUser.setRole(Role.USER);
+        defaultUser.setImage("https://imagehostingservice.org/jnn41kr.png");
+    }
+
+    @Test
+    public void userToUserDtoMappingTest() {
+        UserDto dto = mapper.toUserDto(defaultUser);
+
+        assertEntityEqualsToDto(defaultUser, dto);
+    }
+
+    @Test
+    public void createUserFromRegisterDtoTest() {
+        RegisterDto dto = new RegisterDto();
+        dto.setUsername("morgan.johns1938@example.com");
+        dto.setPassword("qwerty123456");
+        dto.setFirstName("Morgan");
+        dto.setLastName("Johns");
+        dto.setPhone("+7(000)00-00-00");
+        dto.setRole(Role.USER);
+
+        User entity = mapper.createUserFromDto(dto);
+
+        assertEquals(entity.getEmail(), dto.getUsername());
+        assertEquals(entity.getPassword(), dto.getPassword());
+        assertEquals(entity.getFirstName(), dto.getFirstName());
+        assertEquals(entity.getLastName(), dto.getLastName());
+        assertEquals(entity.getPhone(), dto.getPhone());
+        assertEquals(entity.getRole(), dto.getRole());
+    }
+
+    @Test
+    public void updatingUserFromUpdateUserDtoTest() {
+        User entity = new User();
+        entity.setFirstName("Old firstName");
+        entity.setLastName("Old lastName");
+        entity.setPhone("+7(111)111-11-11");
+
+        UpdateUserDto dto = new UpdateUserDto();
+        dto.setFirstName("New firstName");
+        dto.setLastName("New lastName");
+        dto.setPhone("+7(222)222-22-22");
+
+        mapper.updateUserFromDto(entity, dto);
+
+        assertEquals(entity.getFirstName(), dto.getFirstName());
+        assertEquals(entity.getLastName(), dto.getLastName());
+        assertEquals(entity.getPhone(), dto.getPhone());
+    }
+
+    private void assertEntityEqualsToDto(User entity, UserDto dto) {
+        assertEquals(dto.getId(), entity.getId());
+        assertEquals(dto.getEmail(), entity.getEmail());
+        assertEquals(dto.getFirstName(), entity.getFirstName());
+        assertEquals(dto.getLastName(), entity.getLastName());
+        assertEquals(dto.getPhone(), entity.getPhone());
+        assertEquals(dto.getRole(), entity.getRole());
+        assertEquals(dto.getImage(), entity.getImage());
+    }
+
+}


### PR DESCRIPTION
Using MapStruct to map entities <-> DTOs
only fields with different names are explicitly specified in `@Mapping` args 
all the mapping methods covered with tests

closes #5 